### PR TITLE
dev-util/nvidia-cuda-toolkit: bump PYTHON_COMPAT

### DIFF
--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-13.0.2.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-13.0.2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # shellcheck disable=SC2317
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit check-reqs edo toolchain-funcs
 inherit python-r1
 

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-13.1.0.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-13.1.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # shellcheck disable=SC2317
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit check-reqs edo toolchain-funcs
 inherit python-r1
 


### PR DESCRIPTION
Drop python3_11, add python3_14 support.
Mirrors gentoo/gentoo commit 13700abeca52ae60cd614901cdf5911c8a4a5086. 
Closes: https://bugs.gentoo.org/973947